### PR TITLE
[DOC] NIT: nit about single-typed $in and $nin arrays

### DIFF
--- a/docs/core/filters.md
+++ b/docs/core/filters.md
@@ -37,14 +37,42 @@ You can use the following JSON schema to validate your `where` filters:
                                 "$lt": {"type": "number"},
                                 "$lte": {"type": "number"},
                                 "$in": {
-                                    "type": "array",
-                                    "items": {"type": ["string", "number", "boolean"]},
-                                    "minItems": 1
+                                  "oneOf": [
+                                    {
+                                      "type": "array",
+                                      "items": { "type": "string" },
+                                      "minItems": 1
+                                    },
+                                    {
+                                      "type": "array",
+                                      "items": { "type": "number" },
+                                      "minItems": 1
+                                    },
+                                    {
+                                      "type": "array",
+                                      "items": { "type": "boolean" },
+                                      "minItems": 1
+                                    }
+                                  ]
                                 },
                                 "$nin": {
-                                    "type": "array",
-                                    "items": {"type": ["string", "number", "boolean"]},
-                                    "minItems": 1
+                                  "oneOf": [
+                                    {
+                                      "type": "array",
+                                      "items": { "type": "string" },
+                                      "minItems": 1
+                                    },
+                                    {
+                                      "type": "array",
+                                      "items": { "type": "number" },
+                                      "minItems": 1
+                                    },
+                                    {
+                                      "type": "array",
+                                      "items": { "type": "boolean" },
+                                      "minItems": 1
+                                    }
+                                  ]
                                 }
                             },
                             "additionalProperties": False,


### PR DESCRIPTION
Sorry in advance, this is really nit-picky, but I noticed that the jsonschema for the `$nin` and `$in` value arrays allows for a mix of types within the same list, as opposed to a union of single-typed arrays (of different types each).

I feel slightly guilty even submitting this, but I noticed that this doc had been touched recently, so it occurs to me that it's something that is still being maintained, therefore why not make this minor suggestion for a slightly more correct schema.

For context, I had recently been playing around with making a jsonschema like this, so that's why this caught my eye. 🙏 I promise I'm not trying to be a PITA.