### PR TITLE
fix: migrate deprecated envoy exact_match to string_match

### DIFF
--- a/docs/security/auth-1.0.x.md
+++ b/docs/security/auth-1.0.x.md
@@ -44,7 +44,8 @@ static_resources:
                             permissions:
                               - header:
                                   name: %CHROMA_AUTH_TOKEN_TRANSPORT_HEADER%
-                                  exact_match: "%CHROMA_SERVER_AUTHN_CREDENTIALS%"
+                                  string_match:
+                                    exact: %CHROMA_SERVER_AUTHN_CREDENTIALS%
                             principals:
                               - any: true
                   - name: envoy.filters.http.router


### PR DESCRIPTION
The comparison using `exact_match `has been replaced by `string_match.exact`, a new way to compare the token.

Error: in the latest version, if you use `exact_match`, authorization doesn’t work at all.

See the field’s deprecation here: [docs](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto.html#envoy-v3-api-field-config-route-v3-headermatcher-exact-match)