### PR TITLE
docs: add CloudClient docs and update client examples

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,7 @@ Latest ChromaDB version: [1.5.0](https://github.com/chroma-core/chroma/releases/
 - 🔥 [SSL-Terminating Proxies](security/ssl-proxies.md) - Learn how to secure Chroma server with `Envoy` or `Nginx` proxies - 📅`31-Jul-2024`
 - 🗑️ [WAL Pruning](core/advanced/wal-pruning.md#chroma-cli) - Learn how to prune (cleanup) your Chroma database (WAL) with Chroma's built-in CLI `vacuum` command - 📅`30-Jul-2024`
 - ✨ [Multi-Category Filtering](strategies/multi-category-filters.md) - Learn how to filter data based on multiple categories - 📅`15-Jul-2024`
-- 🔒 [Chroma Auth](security/auth.md) - Learn how to secure your Chroma deployment with Authentication - 📅`11-Jul-2024`
+- 🔒 [Chroma Auth](security/auth-1.0.x.md) - Learn how to secure your Chroma deployment with Authentication - 📅`11-Jul-2024`
 - 📦 [Async Http Client](core/clients.md#http-client) - Chroma now supports async HTTP clients - 📅`19-Jun-2024`
 - 🔒 [Security](security/index.md) - Learn how to secure your Chroma deployment - 📅`13-Jun-2024`
 - 🔧 [Installation](core/install.md) - Learn about the different ways to install Chroma - 📅`08-Jun-2024`
@@ -106,7 +106,7 @@ Below is a list of available clients for ChromaDB.
 - ✨ [Multi-User Basic Auth Plugin](strategies/multi-tenancy/multi-user-basic-auth.md) - learn how to build a multi-user
   basic authentication plugin for Chroma.
 - ✨ [CORS Configuration For JS Browser apps](strategies/cors.md) - learn how to configure CORS for Chroma.
-- ✨ [Running Chroma with SystemD](strategies/systemd-service.md) - learn how to start Chroma upon system boot.
+- ✨ [Running Chroma with SystemD](running/systemd-service.md) - learn how to start Chroma upon system boot.
 
 ## Get Help
 

--- a/docs/security/legacy-auth.md
+++ b/docs/security/legacy-auth.md
@@ -13,7 +13,7 @@ Chroma offers built in authentication and authorization mechanisms to secure you
 
 !!! warning "Auth needs the company of SSL/TLS"
 
-    Authentication without encryption is insecure. If you are deploying Chroma in a public-facing environment, it is **highly** recommended that you add [SSL/TLS](ssl-proxy.md).
+    Authentication without encryption is insecure. If you are deploying Chroma in a public-facing environment, it is **highly** recommended that you add [SSL/TLS](ssl-proxies.md).
 
 ## Authentication
 

--- a/docs/strategies/privacy.md
+++ b/docs/strategies/privacy.md
@@ -10,4 +10,4 @@ TBD
 
 #### Client-side Document Encryption
 
-See the [notebook](../../examples/advanced/encryption/client_side_encryption_example.ipynb) on client-side document encryption.
+Client-side document encryption notebook coming soon.


### PR DESCRIPTION
## Summary

- Add new **Cloud Client** section to `clients.md` with Python, TypeScript, Go, and Rust examples
- Update **HTTP Client** section: add Rust tab, modernize TypeScript (v3 `host`/`port`/`ssl`) and Go (v2 API) examples
- Add collapsed note about Go client still being at `amikos-tech/chroma-go`
- Fix 6 broken links across `index.md`, `clients.md`, `legacy-auth.md`, and `privacy.md`

Closes #94

## Test plan

- [x] `mkdocs build` passes with zero warnings
- [ ] Preview all tabs render correctly on the clients page
- [ ] Verify fixed links resolve to the correct pages