### PR TITLE
[DOC] Add array metadata to concepts + runnable filtering examples

### DIFF
--- a/docs/core/concepts.md
+++ b/docs/core/concepts.md
@@ -46,6 +46,21 @@ Metadata values can be of the following types:
 - integers
 - floats (float32)
 - booleans
+- arrays of strings, integers, floats, or booleans (`Chroma >= 1.5.0`)
+
+Array metadata constraints:
+
+- All elements must be the same type
+- Empty arrays are not allowed
+- Nested arrays are not supported
+
+See [Array Metadata](filters.md#array-metadata) for query examples using `$contains` / `$not_contains`.
+
+Runnable examples:
+
+- [Python](https://github.com/amikos-tech/chroma-cookbook/blob/main/examples/filtering/python/filter_examples.py)
+- [TypeScript](https://github.com/amikos-tech/chroma-cookbook/blob/main/examples/filtering/typescript/filter_examples.ts)
+- [Rust](https://github.com/amikos-tech/chroma-cookbook/blob/main/examples/filtering/rust/src/main.rs)
 
 ## Embedding Function
 

--- a/docs/core/filters.md
+++ b/docs/core/filters.md
@@ -9,12 +9,12 @@ Those familiar with MongoDB queries will find Chroma's filters very similar.
 
 !!! tip "Runnable Examples"
 
-    Complete, runnable filtering examples for each language are available in the [examples/filtering](https://github.com/chroma-core/chroma-cookbook/tree/main/examples/filtering) directory:
+    Complete, runnable filtering examples for each language are available in the [examples/filtering](https://github.com/amikos-tech/chroma-cookbook/tree/main/examples/filtering) directory:
 
-    - [Python](https://github.com/chroma-core/chroma-cookbook/blob/main/examples/filtering/python/filter_examples.py)
-    - [TypeScript](https://github.com/chroma-core/chroma-cookbook/blob/main/examples/filtering/typescript/filter_examples.ts)
-    - [Go](https://github.com/chroma-core/chroma-cookbook/blob/main/examples/filtering/go/main.go)
-    - [Rust](https://github.com/chroma-core/chroma-cookbook/blob/main/examples/filtering/rust/src/main.rs)
+    - [Python](https://github.com/amikos-tech/chroma-cookbook/blob/main/examples/filtering/python/filter_examples.py)
+    - [TypeScript](https://github.com/amikos-tech/chroma-cookbook/blob/main/examples/filtering/typescript/filter_examples.ts)
+    - [Go](https://github.com/amikos-tech/chroma-cookbook/blob/main/examples/filtering/go/main.go)
+    - [Rust](https://github.com/amikos-tech/chroma-cookbook/blob/main/examples/filtering/rust/src/main.rs)
 
 ## Metadata Filters
 
@@ -741,6 +741,14 @@ Supported array element types: `string`, `integer`, `float`, `boolean`
 - Empty arrays are not allowed
 - Nested arrays (arrays of arrays) are not supported
 - All elements must be the same type (no mixed-type arrays)
+
+!!! tip "Runnable Array Examples"
+
+    End-to-end array metadata examples are included in the filtering examples:
+
+    - [Python](https://github.com/amikos-tech/chroma-cookbook/blob/main/examples/filtering/python/filter_examples.py)
+    - [TypeScript](https://github.com/amikos-tech/chroma-cookbook/blob/main/examples/filtering/typescript/filter_examples.ts)
+    - [Rust](https://github.com/amikos-tech/chroma-cookbook/blob/main/examples/filtering/rust/src/main.rs)
 
 #### Storing Array Metadata
 


### PR DESCRIPTION
## Summary
This PR completes issue #101 by documenting array metadata in Concepts and aligning runnable filtering examples across languages.

### Documentation updates
- Add array metadata type to `docs/core/concepts.md` with version note (`Chroma >= 1.5.0`) and constraints.
- Add direct links from Concepts to runnable filtering examples.
- Fix stale `chroma-core/chroma-cookbook` links in `docs/core/filters.md` to `amikos-tech/chroma-cookbook`.
- Add a dedicated "Runnable Array Examples" callout in Filters.

### Runnable example updates
- Extend filtering examples to include array metadata data paths and queries where supported.
- Make examples safer and more deterministic for local runs:
  - unique collection names per language (`filter_demo_python`, `filter_demo_typescript`, `filter_demo_go`, `filter_demo_rust`)
  - Go now checks errors for every query/get call instead of ignoring them.
- Python filtering example now uses `HttpClient(host="localhost", port=8000)` to target local Docker Chroma explicitly.

## Validation
Validated against local Docker Chroma (`chromadb/chroma:1.5.0`) with:

- `/Users/tazarov/.pyenv/versions/3.11.7/bin/python3 /Users/tazarov/experiments/chroma/oss/chroma-cookbook/examples/filtering/python/filter_examples.py`
- `cd /Users/tazarov/experiments/chroma/oss/chroma-cookbook/examples/filtering/typescript && npx --yes tsx filter_examples.ts`
- `cd /Users/tazarov/experiments/chroma/oss/chroma-cookbook/examples/filtering/go && go run .`
- `cd /Users/tazarov/experiments/chroma/oss/chroma-cookbook/examples/filtering/rust && cargo run --quiet`

All passed.

## Follow-up
- Concepts audience split (General users vs Power users) is tracked in #118.

Closes #101
