### PR TITLE
docs: align clients.md with current client APIs

### DIFF
--- a/docs/core/clients.md
+++ b/docs/core/clients.md
@@ -3,12 +3,21 @@
 !!! tip "Chroma Settings Object"
 
     The below is only a partial list of Chroma configuration options. For full list check the code
-    [`chromadb.config.Settings`](https://github.com/chroma-core/chroma/blob/c665838b0d143e2c2ceb82c4ade7404dc98124ff/chromadb/config.py#L83) or
+    [`chromadb.config.Settings`](https://github.com/chroma-core/chroma/blob/main/chromadb/config.py) or
     the [ChromaDB Configuration](configuration.md) page.
+
+## Client implementations and source repos
+
+| Language | Constructors covered on this page | Source repository |
+| --- | --- | --- |
+| Python | `PersistentClient`, `HttpClient`, `AsyncHttpClient`, `CloudClient`, `EphemeralClient`, `Client` | [`chroma-core/chroma`](https://github.com/chroma-core/chroma/tree/main/chromadb) |
+| TypeScript | `ChromaClient`, `CloudClient` | [`chroma-core/chroma` (JS client)](https://github.com/chroma-core/chroma/tree/main/clients/js) |
+| Go | `NewHTTPClient`, `NewCloudClient` | [`amikos-tech/chroma-go`](https://github.com/amikos-tech/chroma-go/tree/main/pkg/api/v2) |
+| Rust | `ChromaHttpClient` | [`chroma-core/chroma` (Rust crate)](https://github.com/chroma-core/chroma/tree/main/rust/chroma) |
 
 ## Persistent Client
 
-To create your a local persistent client use the `PersistentClient` class. This client will store all data locally in a
+To create a local persistent client, use the `PersistentClient` class. This client stores data locally in a
 directory on your machine at the path you specify.
 
 !!! tip "Authentication"
@@ -29,12 +38,12 @@ client = chromadb.PersistentClient(
 
 **Parameters**:
 
-1. `path` - parameter must be a local path on the machine where Chroma is running. If the path does not exist, it will
-   be created. The path can be relative or absolute. If the path is not specified, the default is `./chroma` in the
-   current working directory.
-2. `settings` - Chroma settings object.
-3. `tenant` - the tenant to use. Default is `default_tenant`.
-4. `database` - the database to use. Default is `default_database`.
+| Parameter | Type | Description | Default / Allowed values |
+| --- | --- | --- | --- |
+| `path` | `str \| Path` | Local path on the machine where Chroma runs. Created if it does not exist. Can be relative or absolute. | `./chroma` |
+| `settings` | `Settings \| None` | Chroma settings object. | `None` (uses `Settings()`) |
+| `tenant` | `str` | Tenant to use. | `default_tenant` |
+| `database` | `str` | Database to use. | `default_database` |
 
 !!! tip "Positional Parameters"
 
@@ -55,7 +64,7 @@ The persistent client is useful for:
 !!! warn "The right tool for the job"
 
     When evaluating the use of local `PersistentClient` one should always factor in the scale of the application. 
-    Similar to SQLite vs Posgres/MySQL, `PersistentClient` vs `HTTPClient` with Chroma server, application architectural
+    Similar to SQLite vs Postgres/MySQL, `PersistentClient` vs `HTTPClient` with Chroma server, application architectural
     characteristics (such as complexity, scale, performance etc) should be considered when deciding to use one or the other.
 
 ## HTTP Client
@@ -85,15 +94,16 @@ remote ChromaDB server. The HTTP client can operate in synchronous or asynchrono
     ```
     
     **Parameters**:
-    
-    1. `host` - The host of the remote server. If not specified, the default is `localhost`.
-    2. `port` - The port of the remote server. If not specified, the default is `8000`.
-    3. `ssl` - If `True`, the client will use HTTPS. If not specified, the default is `False`.
-    4. `headers` - (optional): The headers to be sent to the server. The setting can be used to pass additional headers to the
-        server. An example of this can be auth headers.
-    5. `settings` - Chroma settings object.
-    6. `tenant` - the tenant to use. Default is `default_tenant`.
-    7. `database` - the database to use. Default is `default_database`.
+
+    | Parameter | Type | Description | Default / Allowed values |
+    | --- | --- | --- | --- |
+    | `host` | `str` | Hostname of the remote server. You can also pass a full URL (including a path prefix). | `localhost` |
+    | `port` | `int` | Port of the remote server. | `8000` |
+    | `ssl` | `bool` | Uses HTTPS when `True`. | `False` |
+    | `headers` | `dict[str, str] \| None` | Additional headers sent with each request (for example auth headers). | `None` |
+    | `settings` | `Settings \| None` | Chroma settings object. | `None` (uses `Settings()`) |
+    | `tenant` | `str` | Tenant to use. | `default_tenant` |
+    | `database` | `str` | Database to use. | `default_database` |
     
     !!! tip "Positional Parameters"
     
@@ -104,35 +114,38 @@ remote ChromaDB server. The HTTP client can operate in synchronous or asynchrono
     ```python
     import asyncio
     import chromadb
+    from chromadb.config import DEFAULT_TENANT, DEFAULT_DATABASE, Settings
     # Apply nest_asyncio to allow running nested event loops in jupyter notebook
     # import nest_asyncio # import this if running in jupyter notebook
     # nest_asyncio.apply() # apply this if running in jupyter notebook
+
     async def list_collections():
-    client = await chromadb.AsyncHttpClient(
-        host="localhost",
-        port=8000,
-        ssl=False,
-        headers=None,
-        settings=Settings(),
-        tenant=DEFAULT_TENANT,
-        database=DEFAULT_DATABASE,
-    )
-    return await client.list_collections()
-    
-    result = asyncio.get_event_loop().run_until_complete(list_collections())
+        client = await chromadb.AsyncHttpClient(
+            host="localhost",
+            port=8000,
+            ssl=False,
+            headers=None,
+            settings=Settings(),
+            tenant=DEFAULT_TENANT,
+            database=DEFAULT_DATABASE,
+        )
+        return await client.list_collections()
+
+    result = asyncio.run(list_collections())
     print(result)
     ```
 
     **Parameters**:
-    
-    1. `host` - The host of the remote server. If not specified, the default is `localhost`.
-    2. `port` - The port of the remote server. If not specified, the default is `8000`.
-    3. `ssl` - If `True`, the client will use HTTPS. If not specified, the default is `False`.
-    4. `headers` - (optional): The headers to be sent to the server. The setting can be used to pass additional headers to the
-        server. An example of this can be auth headers.
-    5. `settings` - Chroma settings object.
-    6. `tenant` - the tenant to use. Default is `default_tenant`.
-    7. `database` - the database to use. Default is `default_database`.
+
+    | Parameter | Type | Description | Default / Allowed values |
+    | --- | --- | --- | --- |
+    | `host` | `str` | Hostname of the remote server. You can also pass a full URL (including a path prefix). | `localhost` |
+    | `port` | `int` | Port of the remote server. | `8000` |
+    | `ssl` | `bool` | Uses HTTPS when `True`. | `False` |
+    | `headers` | `dict[str, str] \| None` | Additional headers sent with each request (for example auth headers). | `None` |
+    | `settings` | `Settings \| None` | Chroma settings object. | `None` (uses `Settings()`) |
+    | `tenant` | `str` | Tenant to use. | `default_tenant` |
+    | `database` | `str` | Database to use. | `default_database` |
     
     !!! tip "Positional Parameters"
     
@@ -144,10 +157,12 @@ remote ChromaDB server. The HTTP client can operate in synchronous or asynchrono
     import { ChromaClient } from "chromadb";
 
     const client = new ChromaClient({
-        host: "localhost",
-        port: 8000,
-        ssl: false,
-        headers: { "x-chroma-token": "your_token_here" },
+        path: "http://localhost:8000",
+        auth: {
+            provider: "token",
+            credentials: "your_token_here",
+            tokenHeaderType: "X_CHROMA_TOKEN",
+        },
         tenant: "default_tenant",
         database: "default_database",
     });
@@ -155,12 +170,13 @@ remote ChromaDB server. The HTTP client can operate in synchronous or asynchrono
 
     **Parameters**:
 
-    - `host` - The hostname of the remote server. Default is `localhost`.
-    - `port` - The port of the remote server. Default is `8000`.
-    - `ssl` - If `true`, the client will use HTTPS. Default is `false`.
-    - `headers` - Custom HTTP headers (e.g. authentication tokens).
-    - `tenant` - the tenant to use. Default is `default_tenant`.
-    - `database` - the database to use. Default is `default_database`.
+    | Parameter | Type | Description | Default / Allowed values |
+    | --- | --- | --- | --- |
+    | `path` | `string` | Base URL for the Chroma API. | `http://localhost:8000` |
+    | `auth` | `AuthOptions` | Authentication config. | Optional. `provider` values: `"basic"` or `"token"` |
+    | `fetchOptions` | `RequestInit` | Fetch options passed to HTTP calls (for example custom headers). | Optional |
+    | `tenant` | `string` | Tenant to use. | `default_tenant` |
+    | `database` | `string` | Database to use. | `default_database` |
 
 === "Go"
 
@@ -193,10 +209,14 @@ remote ChromaDB server. The HTTP client can operate in synchronous or asynchrono
 
     **Parameters**:
 
-    - `WithBaseURL()` - the Chroma endpoint URL e.g. `http://localhost:8000`.
-    - `WithAuth()` - Chroma authentication provider (see more [here](https://go-client.chromadb.dev/auth/)).
-    - `WithDatabaseAndTenant()` - set database and tenant explicitly.
-    - `WithDefaultDatabaseAndTenant()` - use `default_tenant` and `default_database`.
+    | Option | Type | Description | Default / Allowed values |
+    | --- | --- | --- | --- |
+    | `WithBaseURL()` | `func(string) ClientOption` | Sets Chroma endpoint URL. `/api/v2` is appended if missing. | Default base URL is `http://localhost:8000/api/v2` |
+    | `WithAuth()` | `func(CredentialsProvider) ClientOption` | Sets auth provider (see [Go auth docs](https://go-client.chromadb.dev/auth/)). | Optional |
+    | `WithDatabaseAndTenant()` | `func(database string, tenant string) ClientOption` | Sets database and tenant explicitly. | Optional |
+    | `WithDatabaseAndTenantFromEnv()` | `func() ClientOption` | Reads `CHROMA_DATABASE` and `CHROMA_TENANT` when present. | Applied by default in `NewHTTPClient` |
+    | `WithDefaultDatabaseAndTenant()` | `func() ClientOption` | Fills missing values with defaults. | `default_database` and `default_tenant` |
+    | `WithTimeout()` | `func(time.Duration) ClientOption` | Sets request timeout. | Optional |
 
 === "Rust"
 
@@ -217,10 +237,13 @@ remote ChromaDB server. The HTTP client can operate in synchronous or asynchrono
 
     **Parameters** (`ChromaHttpClientOptions`):
 
-    - `endpoint` - Server base URL. Default is `http://localhost:8000`.
-    - `auth_method` - Authentication strategy. Default is `ChromaAuthMethod::None`.
-    - `tenant_id` - Tenant identifier. Auto-resolved if omitted.
-    - `database_name` - Database name. Auto-resolved if omitted.
+    | Parameter | Type | Description | Default / Allowed values |
+    | --- | --- | --- | --- |
+    | `endpoint` | `reqwest::Url` | Server base URL. | `http://localhost:8000` |
+    | `auth_method` | `ChromaAuthMethod` | Authentication strategy. | `ChromaAuthMethod::None` |
+    | `retry_options` | `ChromaRetryOptions` | Retry/backoff behavior for failed requests. | `max_retries=3`, `min_delay=200ms`, `max_delay=5s`, `jitter=true` |
+    | `tenant_id` | `Option<String>` | Tenant identifier override. | `None` (resolved from identity when possible) |
+    | `database_name` | `Option<String>` | Database name override. | `None` (resolved when possible; explicit value recommended if multiple DBs are accessible) |
 
     You can also construct a client from environment variables (`CHROMA_ENDPOINT`, `CHROMA_TENANT`, `CHROMA_DATABASE`):
 
@@ -247,7 +270,7 @@ important to note that there are trade-offs associated with using HTTP client:
 
 ### Host parameter special cases (Python-only)
 
-The `host` parameter supports a more advanced syntax than just the hostname. You can specify the whole endpoint ULR (
+The `host` parameter supports a more advanced syntax than just the hostname. You can specify the whole endpoint URL (
 without the API paths), e.g. `https://chromadb.example.com:8000/my_server/path/`. This is useful when you want to use a
 reverse proxy or load balancer in front of your ChromaDB server.
 
@@ -258,11 +281,14 @@ configuration automatically.
 
 !!! note "Environment Variables"
 
-    All languages support configuration via environment variables. When `CHROMA_API_KEY`, `CHROMA_TENANT`, and
-    `CHROMA_DATABASE` are set, the client can be instantiated with no arguments.
+    Cloud environment variable handling differs by language:
 
-    If your API key is scoped to a single database, tenant and database are auto-resolved from the key —
-    you only need to provide the API key.
+    | Language | API key | Tenant / database |
+    | --- | --- | --- |
+    | Python | `api_key` arg or `CHROMA_API_KEY` | `tenant`/`database` args, or `CHROMA_TENANT`/`CHROMA_DATABASE`, or auto-resolved from scoped credentials |
+    | TypeScript | `apiKey` arg or `CHROMA_API_KEY` | Constructor args (`tenant`, `database`) |
+    | Go | `WithCloudAPIKey()` or `CHROMA_API_KEY` | `WithDatabaseAndTenant()` or `CHROMA_TENANT` + `CHROMA_DATABASE` |
+    | Rust | `ChromaHttpClientOptions::cloud(...)` or `CHROMA_API_KEY` | Explicit options or `CHROMA_TENANT`/`CHROMA_DATABASE`; otherwise resolved from identity when possible |
 
 === "Python"
 
@@ -282,10 +308,15 @@ configuration automatically.
 
     **Parameters**:
 
-    - `api_key` - Chroma Cloud API key. Falls back to `CHROMA_API_KEY` env var.
-    - `tenant` - Tenant identifier. Falls back to `CHROMA_TENANT` env var, or auto-resolved from API key.
-    - `database` - Database name. Falls back to `CHROMA_DATABASE` env var, or auto-resolved from API key.
-    - `settings` - Chroma Settings object to override defaults.
+    | Parameter | Type | Description | Default / Allowed values |
+    | --- | --- | --- | --- |
+    | `api_key` | `str \| None` | Chroma Cloud API key. | Required. Falls back to `CHROMA_API_KEY` |
+    | `tenant` | `str \| None` | Tenant identifier. | Falls back to `CHROMA_TENANT`, then auth-based resolution |
+    | `database` | `str \| None` | Database name. | Falls back to `CHROMA_DATABASE`, then auth-based resolution |
+    | `settings` | `Settings \| None` | Settings override. | `None` (uses `Settings()`) |
+    | `cloud_host` | `str` | Cloud API hostname (keyword-only; primarily for testing). | `api.trychroma.com` |
+    | `cloud_port` | `int` | Cloud API port (keyword-only; primarily for testing). | `443` |
+    | `enable_ssl` | `bool` | Enables TLS (keyword-only; primarily for testing). | `True` |
 
 === "TypeScript"
 
@@ -301,9 +332,13 @@ configuration automatically.
 
     **Parameters**:
 
-    - `apiKey` - Chroma Cloud API key. Falls back to `CHROMA_API_KEY` env var.
-    - `tenant` - Tenant identifier. Falls back to `CHROMA_TENANT` env var.
-    - `database` - Database name. Falls back to `CHROMA_DATABASE` env var.
+    | Parameter | Type | Description | Default / Allowed values |
+    | --- | --- | --- | --- |
+    | `apiKey` | `string \| undefined` | Chroma Cloud API key. | Required. Falls back to `CHROMA_API_KEY` |
+    | `tenant` | `string \| undefined` | Tenant identifier. | Optional. Defaults to `default_tenant` in underlying `ChromaClient` |
+    | `database` | `string \| undefined` | Database name. | Optional. Defaults to `default_database` in underlying `ChromaClient` |
+    | `cloudHost` | `string \| undefined` | Cloud host prefix. | `https://api.trychroma.com` |
+    | `cloudPort` | `string \| undefined` | Cloud port suffix. | `8000` |
 
 === "Go"
 
@@ -333,9 +368,14 @@ configuration automatically.
 
     **Parameters**:
 
-    - `WithCloudAPIKey()` - Chroma Cloud API key. Falls back to `CHROMA_API_KEY` env var.
-    - `WithDatabaseAndTenant()` - Set database and tenant explicitly.
-    - `WithTimeout()` - Request timeout.
+    | Option | Type | Description | Default / Allowed values |
+    | --- | --- | --- | --- |
+    | `WithCloudAPIKey()` | `func(string) ClientOption` | Sets Chroma Cloud API key. | Falls back to `CHROMA_API_KEY` |
+    | `WithDatabaseAndTenant()` | `func(database string, tenant string) ClientOption` | Sets database and tenant explicitly. | Required unless both env vars are set |
+    | `WithDatabaseAndTenantFromEnv()` | `func() ClientOption` | Reads `CHROMA_DATABASE` and `CHROMA_TENANT`. | Applied by default in `NewCloudClient` |
+    | `WithTimeout()` | `func(time.Duration) ClientOption` | Sets request timeout. | Optional |
+
+    `NewCloudClient` requires non-default tenant and database values and also requires an API key.
 
     ??? note "Go Client Package"
 
@@ -368,15 +408,19 @@ configuration automatically.
 
     **Parameters** (`ChromaHttpClientOptions::cloud()`):
 
-    - `api_key` - Chroma Cloud API key.
-    - `database_name` - Database name. Tenant is auto-resolved.
+    | Parameter | Type | Description | Default / Allowed values |
+    | --- | --- | --- | --- |
+    | `api_key` | `impl Into<String>` | Chroma Cloud API key. | Required |
+    | `database_name` | `impl Into<String>` | Database name used for collection operations. | Required |
 
     **Environment-based** (`ChromaHttpClient::cloud()`):
 
-    - `CHROMA_API_KEY` (required)
-    - `CHROMA_ENDPOINT` (optional, defaults to `https://api.trychroma.com`)
-    - `CHROMA_TENANT` (optional, auto-resolved)
-    - `CHROMA_DATABASE` (optional, auto-resolved)
+    | Variable | Required | Description | Default / Allowed values |
+    | --- | --- | --- | --- |
+    | `CHROMA_API_KEY` | Yes | Cloud API key. | None |
+    | `CHROMA_ENDPOINT` | No | Cloud endpoint override. | `https://api.trychroma.com` |
+    | `CHROMA_TENANT` | No | Tenant override. | If omitted, resolved from identity when possible |
+    | `CHROMA_DATABASE` | No | Database override. | If omitted, resolved from identity when possible |
 
 ## Ephemeral Client
 
@@ -396,36 +440,36 @@ client = chromadb.EphemeralClient(
 
 **Parameters**:
 
-1. `settings` - Chroma settings object.
-2. `tenant` - the tenant to use. Default is `default_tenant`.
-3. `database`  - the database to use. Default is `default_database`.
+| Parameter | Type | Description | Default / Allowed values |
+| --- | --- | --- | --- |
+| `settings` | `Settings \| None` | Chroma settings object. | `None` (uses `Settings()`) |
+| `tenant` | `str` | Tenant to use. | `default_tenant` |
+| `database` | `str` | Database to use. | `default_database` |
 
 !!! tip "Positional Parameters"
 
-    Chroma `PersistentClient` parameters are positional, unless keyword arguments are used.
+    Chroma `EphemeralClient` parameters are positional, unless keyword arguments are used.
 
-## Environmental Variable Configured Client
+## Environment Variable Configured Client
 
-You can also configure the client using environmental variables. This is useful when you want to configure any of the
-client configurations listed above via environmental variables.
+You can also configure the client using environment variables. This is useful when you want to configure any of the
+client options listed above via environment variables.
 
 ```python
 import chromadb
-from chromadb.config import DEFAULT_TENANT, DEFAULT_DATABASE, Settings
 
-client = chromadb.Client(
-    settings=Settings(),
-    tenant=DEFAULT_TENANT,
-    database=DEFAULT_DATABASE,
-)
+# Uses configured defaults from environment/.env/settings.
+client = chromadb.Client()
 ```
 
 **Parameters**:
 
-1. `settings` - Chroma settings object.
-2. `tenant` - the tenant to use. Default is `default_tenant`.
-3. `database` - the database to use. Default is `default_database`.
+| Parameter | Type | Description | Default / Allowed values |
+| --- | --- | --- | --- |
+| `settings` | `Settings` | Settings object for environment and runtime configuration. | Current global settings (`chromadb.get_settings()`) |
+| `tenant` | `str` | Tenant to use. | `default_tenant` |
+| `database` | `str` | Database to use. | `default_database` |
 
 !!! tip "Positional Parameters"
 
-    Chroma `PersistentClient` parameters are positional, unless keyword arguments are used.
+    Chroma `Client` parameters are positional, unless keyword arguments are used.


### PR DESCRIPTION
## Summary
- audit `/Users/tazarov/experiments/chroma/oss/chroma-cookbook/docs/core/clients.md` against current Python, TypeScript, Go, and Rust client constructors/options
- replace parameter bullets with tables containing type, description, and defaults/allowed values
- fix incorrect examples/wording (notably TS HTTP params and Python async snippet)

## Validation
- `mkdocs build -q`
