### PR TITLE
Refresh Resource Requirements page with interactive calculator

### DIFF
--- a/docs/core/resources.md
+++ b/docs/core/resources.md
@@ -2,19 +2,84 @@
 
 Chroma makes use of the following compute resources:
 
-- RAM - Chroma stores the vector HNSW index in-memory. This allows it to perform blazing fast semantic searches.
-- Disk - Chroma persists all data to disk. This includes the vector HNSW index, metadata index, system DB, and the
-  write-ahead log (WAL).
-- CPU - Chroma uses CPU for indexing and searching vectors.
+- RAM - In single-node/self-hosted deployments, Chroma keeps vector search structures in memory for low-latency search.
+- Disk - Chroma persists data to disk, including the vector index files, metadata index, system DB, and write-ahead
+  log (WAL).
+- CPU - Chroma uses CPU for ingest, indexing, filtering, and search execution.
 
-Here are some formulas and heuristics to help you estimate the resources you need to run Chroma.
+Use the formulas and heuristics below to estimate Chroma resource needs.
+
+!!! info "Scope"
+
+    This page is primarily for single-node/self-hosted sizing (HNSW-based indexing).
+    Distributed/Cloud deployments use different index internals (SPANN) and different resource behavior.
+    See [Core Concepts](concepts.md#how-data-flows-through-chroma-cloud-distributed-chroma) and
+    [SPANN Index Configuration](configuration.md#spann-index-configuration) for the distributed model.
 
 ## RAM
 
-Once you select your embedding model, use the following formula for calculating RAM storage requirements for the vector
-HNSW index:
+Once you select your embedding model, start with this lower-bound estimate for vector payload memory:
 
-`number of vectors` * `dimensionality of vectors` * `4 bytes` = `RAM required`
+<div class="resource-formula" role="group" aria-label="Vector payload formulas">
+  <math class="resource-formula__math" display="block" aria-label="payload bytes equals vectors times dimensions times 4">
+    <mrow>
+      <mtext>payload_bytes</mtext>
+      <mo>=</mo>
+      <mtext>vectors</mtext>
+      <mo>&#x00D7;</mo>
+      <mtext>dimensions</mtext>
+      <mo>&#x00D7;</mo>
+      <mn>4</mn>
+    </mrow>
+  </math>
+  <math class="resource-formula__math" display="block" aria-label="payload gib equals payload bytes divided by 1024 cubed">
+    <mrow>
+      <mtext>payload_gib</mtext>
+      <mo>=</mo>
+      <mfrac>
+        <mtext>payload_bytes</mtext>
+        <msup>
+          <mn>1024</mn>
+          <mn>3</mn>
+        </msup>
+      </mfrac>
+    </mrow>
+  </math>
+</div>
+
+Example (`10,000,000` vectors, `1536` dimensions):
+
+<div class="resource-formula resource-formula--example" role="group" aria-label="Vector payload example">
+  <math class="resource-formula__math" display="block" aria-label="payload bytes equals ten million times 1536 times 4 equals 61440000000">
+    <mrow>
+      <mtext>payload_bytes</mtext>
+      <mo>=</mo>
+      <mn>10,000,000</mn>
+      <mo>&#x00D7;</mo>
+      <mn>1536</mn>
+      <mo>&#x00D7;</mo>
+      <mn>4</mn>
+      <mo>=</mo>
+      <mn>61,440,000,000</mn>
+    </mrow>
+  </math>
+  <math class="resource-formula__math" display="block" aria-label="payload gib equals 61440000000 divided by 1024 cubed approximately 57.2">
+    <mrow>
+      <mtext>payload_gib</mtext>
+      <mo>=</mo>
+      <mfrac>
+        <mn>61,440,000,000</mn>
+        <msup>
+          <mn>1024</mn>
+          <mn>3</mn>
+        </msup>
+      </mfrac>
+      <mo>&#x2248;</mo>
+      <mn>57.2</mn>
+      <mtext>&#x00A0;GiB</mtext>
+    </mrow>
+  </math>
+</div>
 
 - `number of vectors` - This is the number of vectors you plan to index. These are the documents in your Chroma
   collection (or chunks if you use LlamaIndex or LangChain terminology).
@@ -23,14 +88,110 @@ HNSW index:
 - `4 bytes` - This is the size of each component of a vector. Chroma relies on HNSW lib implementation that uses 32bit
   floats.
 
+Treat this as a lower-bound estimate. Real memory usage is higher because of:
+
+- HNSW graph/link overhead (affected by HNSW settings such as `hnsw:M` and `hnsw:construction_ef`)
+- In-memory bruteforce buffer (`hnsw:batch_size`) before vectors are merged into HNSW
+- Query-time and filter working memory, plus normal process overhead
+
+For production sizing, add headroom and validate under realistic load.
+
+## Quick Resource Calculator
+
+Use this lightweight estimator to get a practical starting point.
+
+<div class="resource-calc" data-resource-calculator>
+  <div class="resource-calc__inputs">
+    <label class="resource-calc__field resource-calc__field--vectors">
+      <span>Dataset size (number of vectors)</span>
+      <input data-input="vector_stop" type="range" min="0" max="3" step="1" value="2" />
+      <div class="resource-calc__ticks" aria-hidden="true">
+        <span>10k</span>
+        <span>100k</span>
+        <span>1M</span>
+        <span>10M</span>
+      </div>
+      <div class="resource-calc__current">
+        Selected:
+        <strong data-output="vector_count">-</strong>
+      </div>
+    </label>
+    <label class="resource-calc__field resource-calc__field--model">
+      <span>Embedding model (dimension)</span>
+      <select data-input="model_dimension">
+        <option value="384">MiniLM (384)</option>
+        <option value="1024">Cohere (1024)</option>
+        <option value="1536" selected>OAI 3-small (1536)</option>
+        <option value="3072">OAI 3-large (3072)</option>
+      </select>
+    </label>
+    <label class="resource-calc__field resource-calc__field--memory">
+      <span>Memory profile</span>
+      <select data-input="memory_profile">
+        <option value="balanced" selected>Balanced (+30%)</option>
+        <option value="lean">Lean prototype (+15%)</option>
+        <option value="heavy">Heavy query load (+50%)</option>
+      </select>
+    </label>
+    <label class="resource-calc__field resource-calc__field--storage">
+      <span>Storage profile</span>
+      <select data-input="storage_profile">
+        <option value="typical" selected>Typical mixed (~3x)</option>
+        <option value="vector_heavy">Vector-heavy (~2x)</option>
+        <option value="metadata_heavy">Metadata-heavy (~4x)</option>
+      </select>
+    </label>
+  </div>
+
+  <div class="resource-calc__results">
+    <div class="resource-calc__card">
+      <div class="resource-calc__label">Vector payload</div>
+      <div class="resource-calc__value" data-output="payload_gib">-</div>
+    </div>
+    <div class="resource-calc__card">
+      <div class="resource-calc__label">Estimated RAM</div>
+      <div class="resource-calc__value" data-output="ram_gib">-</div>
+    </div>
+    <div class="resource-calc__card">
+      <div class="resource-calc__label">Estimated Disk</div>
+      <div class="resource-calc__value" data-output="disk_gib">-</div>
+    </div>
+    <div class="resource-calc__card">
+      <div class="resource-calc__label">CPU hint</div>
+      <div class="resource-calc__value" data-output="vcpu_hint">-</div>
+    </div>
+  </div>
+
+  <p class="resource-calc__note">
+    This calculator is for single-node/self-hosted sizing. For distributed/cloud (SPANN), see
+    <a href="../concepts/#how-data-flows-through-chroma-cloud-distributed-chroma">Core Concepts</a> and
+    <a href="../configuration/#spann-index-configuration">SPANN Index Configuration</a>.
+  </p>
+</div>
+
+!!! warning "Important: vector-first estimate"
+
+    This calculator is **vector-first** and does not fully model document or index growth.
+    If you store large documents (near model context limits), **document and metadata storage can exceed vector storage**.
+    Chroma also maintains a SQLite full-text index (`embedding_fulltext_search`) used by `where_document` queries, which adds disk overhead.
+    See [Storage Layout](storage-layout.md#metadata-segment) and [Filters](filters.md) for details.
+
 ## Disk
 
-Disk storage requirements mainly depend on what metadata you store and the number of vectors you index. The heuristics
-is at least 2-4x the RAM required for the vector HNSW index.
+Disk storage requirements depend on vectors, documents, metadata, and WAL behavior.
+
+Use these heuristics:
+
+- Start with at least the raw vector footprint plus several GB for metadata/documents/system data
+- In many workloads, `2-4x` the vector payload estimate is a reasonable planning range
+- If you store large documents/metadata blobs, disk needs can exceed that range
+- If you rely on document filtering (`where_document`), plan additional space for SQLite FTS index structures
 
 !!! note "WAL Cleanup"
 
-    Since version `0.5.6` Chroma automatically cleans up the WAL file.
+    Recent Chroma versions support automatic WAL pruning.
+    If your persistent data directory was created on older versions, or if auto-pruning is disabled, run WAL cleanup once and verify WAL config.
+    See [WAL Pruning](advanced/wal-pruning.md) and [Maintenance](../running/maintenance.md#wal-configuration).
 
 ### Temporary Disk Space
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,7 @@ Latest ChromaDB version: [1.5.1](https://github.com/chroma-core/chroma/releases/
 
 ## New and Noteworthy
 
+- 📊 [Resource Requirements](core/resources.md) - Added an interactive sizing calculator, clearer RAM formulas, and explicit disk caveats for large documents and FTS index overhead - 📅`21-Feb-2026`
 - 🚀 [Running Chroma](running/running-chroma.md) - Refreshed CLI/Docker/Compose/Minikube guidance, aligned Helm chart notes, and added collapsed optional YAML config examples - 📅`20-Feb-2026`
 - 🧭 [Core Concepts](core/concepts.md) - Reworked into General vs Power Users tracks, with interactive local/distributed execution diagrams and data-flow visuals - 📅`19-Feb-2026`
 - 🎯 [Collections Query IDs](core/collections.md#constrain-query-candidates-by-id) - Documented `query(..., ids=...)` for restricting similarity search to specific records - 📅`17-Feb-2026`

--- a/docs/javascripts/resource-calculator.js
+++ b/docs/javascripts/resource-calculator.js
@@ -1,0 +1,126 @@
+(() => {
+  const BYTES_PER_FLOAT32 = 4;
+  const BYTES_PER_GIB = 1024 ** 3;
+  const VECTOR_STOPS = [10000, 100000, 1000000, 10000000];
+  const MEMORY_PROFILES = {
+    lean: 15,
+    balanced: 30,
+    heavy: 50,
+  };
+  const STORAGE_PROFILES = {
+    vector_heavy: 2,
+    typical: 3,
+    metadata_heavy: 4,
+  };
+
+  const parsePositive = (value, fallback) => {
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+      return fallback;
+    }
+    return parsed;
+  };
+
+  const formatGiB = (value) => `${value.toFixed(2)} GiB`;
+
+  const initResourceCalculator = (root) => {
+    const scope =
+      root && typeof root.querySelectorAll === "function" ? root : document;
+    const calculators = scope.querySelectorAll("[data-resource-calculator]");
+
+    calculators.forEach((calculator) => {
+      if (!(calculator instanceof HTMLElement)) {
+        return;
+      }
+      if (calculator.dataset.initialized === "true") {
+        return;
+      }
+      calculator.dataset.initialized = "true";
+
+      const vectorStopInput = calculator.querySelector(
+        '[data-input="vector_stop"]'
+      );
+      const modelDimensionInput = calculator.querySelector(
+        '[data-input="model_dimension"]'
+      );
+      const memoryProfileInput = calculator.querySelector(
+        '[data-input="memory_profile"]'
+      );
+      const storageProfileInput = calculator.querySelector(
+        '[data-input="storage_profile"]'
+      );
+
+      const vectorCountOutput = calculator.querySelector(
+        '[data-output="vector_count"]'
+      );
+      const payloadOutput = calculator.querySelector(
+        '[data-output="payload_gib"]'
+      );
+      const ramOutput = calculator.querySelector('[data-output="ram_gib"]');
+      const diskOutput = calculator.querySelector('[data-output="disk_gib"]');
+      const vcpuOutput = calculator.querySelector('[data-output="vcpu_hint"]');
+
+      if (
+        !(vectorStopInput instanceof HTMLInputElement) ||
+        !(modelDimensionInput instanceof HTMLSelectElement) ||
+        !(memoryProfileInput instanceof HTMLSelectElement) ||
+        !(storageProfileInput instanceof HTMLSelectElement) ||
+        !(vectorCountOutput instanceof HTMLElement) ||
+        !(payloadOutput instanceof HTMLElement) ||
+        !(ramOutput instanceof HTMLElement) ||
+        !(diskOutput instanceof HTMLElement) ||
+        !(vcpuOutput instanceof HTMLElement)
+      ) {
+        return;
+      }
+
+      const recalculate = () => {
+        const stopIndex = Math.min(
+          VECTOR_STOPS.length - 1,
+          Math.max(0, Math.round(Number(vectorStopInput.value) || 0))
+        );
+        const vectors = VECTOR_STOPS[stopIndex];
+        const dimensions = parsePositive(modelDimensionInput.value, 1);
+        const headroom =
+          MEMORY_PROFILES[memoryProfileInput.value] ?? MEMORY_PROFILES.balanced;
+        const diskMultiplier =
+          STORAGE_PROFILES[storageProfileInput.value] ??
+          STORAGE_PROFILES.typical;
+
+        const payloadBytes = vectors * dimensions * BYTES_PER_FLOAT32;
+        const payloadGiB = payloadBytes / BYTES_PER_GIB;
+        const estimatedRamGiB = payloadGiB * (1 + headroom / 100);
+        const estimatedDiskGiB = payloadGiB * diskMultiplier;
+        const vcpuHint = Math.max(1, Math.ceil(estimatedRamGiB / 4));
+
+        vectorCountOutput.textContent = vectors.toLocaleString("en-US");
+        payloadOutput.textContent = formatGiB(payloadGiB);
+        ramOutput.textContent = formatGiB(estimatedRamGiB);
+        diskOutput.textContent = formatGiB(estimatedDiskGiB);
+        vcpuOutput.textContent = `${vcpuHint} vCPU`;
+      };
+
+      [
+        vectorStopInput,
+        modelDimensionInput,
+        memoryProfileInput,
+        storageProfileInput,
+      ].forEach((input) => {
+        input.addEventListener("input", recalculate);
+        input.addEventListener("change", recalculate);
+      });
+
+      recalculate();
+    });
+  };
+
+  document.addEventListener("DOMContentLoaded", () => {
+    initResourceCalculator(document);
+  });
+
+  if (typeof document$ !== "undefined" && document$) {
+    document$.subscribe((root) => {
+      initResourceCalculator(root);
+    });
+  }
+})();

--- a/docs/stylesheets/custom.css
+++ b/docs/stylesheets/custom.css
@@ -13,3 +13,168 @@
   min-width: 100%;
   width: 100%;
 }
+
+.md-typeset .resource-formula {
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 0.55rem;
+  padding: 0.55rem 0.75rem;
+  margin: 0.6rem 0 0.8rem;
+  background: var(--md-code-bg-color);
+}
+
+.md-typeset .resource-formula--example {
+  margin-top: 0.35rem;
+}
+
+.md-typeset .resource-formula__math {
+  margin: 0.12rem 0;
+  overflow-x: auto;
+  font-size: 1rem;
+  line-height: 1.35;
+}
+
+.md-typeset .resource-calc {
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 0.6rem;
+  padding: 0.85rem;
+  margin: 0.75rem 0 1.25rem;
+  background: var(--md-default-bg-color);
+}
+
+.md-typeset .resource-calc__inputs {
+  display: grid;
+  gap: 0.7rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-bottom: 0.75rem;
+}
+
+.md-typeset .resource-calc__field--vectors {
+  grid-column: 1 / -1;
+}
+
+.md-typeset .resource-calc__field {
+  display: grid;
+  gap: 0.28rem;
+  font-size: 0.68rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  color: var(--md-default-fg-color--light);
+}
+
+.md-typeset .resource-calc__field input {
+  width: 100%;
+  border: 1px solid var(--md-default-fg-color--lighter);
+  border-radius: 0.45rem;
+  padding: 0.45rem 0.55rem;
+  font-size: 0.88rem;
+  background: var(--md-default-bg-color);
+  color: var(--md-default-fg-color);
+}
+
+.md-typeset .resource-calc__field select {
+  width: 100%;
+  border: 1px solid var(--md-default-fg-color--lighter);
+  border-radius: 0.45rem;
+  padding: 0.45rem 0.55rem;
+  font-size: 0.88rem;
+  min-height: 2.55rem;
+  background: var(--md-default-bg-color);
+  color: var(--md-default-fg-color);
+}
+
+.md-typeset .resource-calc__field input[type="range"] {
+  padding: 0;
+  border: 0;
+  height: 1.3rem;
+  accent-color: var(--md-primary-fg-color);
+}
+
+.md-typeset .resource-calc__ticks {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0.2rem;
+  font-size: 0.66rem;
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+.md-typeset .resource-calc__ticks span:nth-child(1) {
+  text-align: left;
+}
+
+.md-typeset .resource-calc__ticks span:nth-child(2),
+.md-typeset .resource-calc__ticks span:nth-child(3) {
+  text-align: center;
+}
+
+.md-typeset .resource-calc__ticks span:nth-child(4) {
+  text-align: right;
+}
+
+.md-typeset .resource-calc__current {
+  font-size: 0.75rem;
+  text-transform: none;
+  letter-spacing: 0;
+  color: var(--md-default-fg-color);
+}
+
+.md-typeset .resource-calc__results {
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.md-typeset .resource-calc__card {
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 0.45rem;
+  padding: 0.5rem 0.62rem;
+  background: var(--md-code-bg-color);
+}
+
+.md-typeset .resource-calc__label {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  color: var(--md-default-fg-color--light);
+  margin-bottom: 0.2rem;
+}
+
+.md-typeset .resource-calc__value {
+  font-size: 0.96rem;
+  font-weight: 700;
+}
+
+.md-typeset .resource-calc__note {
+  margin: 0.7rem 0 0;
+  color: var(--md-default-fg-color--light);
+  font-size: 0.76rem;
+}
+
+@media (max-width: 980px) {
+  .md-typeset .resource-calc__inputs {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .md-typeset .resource-calc__field--vectors {
+    grid-column: 1 / -1;
+  }
+
+  .md-typeset .resource-calc__results {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .md-typeset .resource-calc__inputs {
+    grid-template-columns: 1fr;
+  }
+
+  .md-typeset .resource-calc__field--vectors {
+    grid-column: auto;
+  }
+
+  .md-typeset .resource-calc__results {
+    grid-template-columns: 1fr;
+  }
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,7 @@ extra_javascript:
   - javascripts/gtag.js
   - javascripts/ethicalads-init.js
   - javascripts/concepts-pipeline.js
+  - javascripts/resource-calculator.js
 extra_css:
   - stylesheets/ethicalads.css
   - stylesheets/concepts-flow.css


### PR DESCRIPTION
## Summary
- refresh `docs/core/resources.md` with clearer RAM/disk guidance and MathML formula display
- add an embedded, lightweight resource calculator (slider + model/profile selects)
- add explicit caveats for document payload growth and SQLite FTS index overhead
- add the update to `docs/index.md` New and Noteworthy
- wire calculator script via `mkdocs.yml` and style it in `docs/stylesheets/custom.css`

## Validation
- `mkdocs build --strict`
- `mkdocs build`
- `python -m pytest -q` (no tests present in this repo)
- smoke check: `curl -I http://127.0.0.1:8088/core/resources/` returned `200`
