### PR TITLE
fix: keep ad banner visible without covering nav/content

### DIFF
--- a/docs/javascripts/ethicalads-init.js
+++ b/docs/javascripts/ethicalads-init.js
@@ -3,9 +3,44 @@
     return;
   }
 
+  const DESKTOP_SIDEBAR_MEDIA = "(min-width: 60em)";
+  const CONTAINER_SELECTOR = ".mdx-ethicalads-container";
+
+  const syncAdPlacement = () => {
+    const containers = Array.from(document.querySelectorAll(CONTAINER_SELECTOR));
+    if (containers.length === 0) {
+      return;
+    }
+
+    // Keep a single ad container across instant navigation updates.
+    const [container, ...duplicates] = containers;
+    duplicates.forEach((node) => node.remove());
+
+    const onDesktop = window.matchMedia(DESKTOP_SIDEBAR_MEDIA).matches;
+    const secondary = document.querySelector(".md-sidebar--secondary .md-sidebar__inner");
+    const primary = document.querySelector(".md-sidebar--primary .md-sidebar__inner");
+    const sidebarTarget = secondary || primary;
+
+    if (onDesktop && sidebarTarget) {
+      if (container.parentElement !== sidebarTarget || sidebarTarget.firstElementChild !== container) {
+        sidebarTarget.prepend(container);
+      }
+      container.setAttribute("data-placement", "sidebar");
+      return;
+    }
+
+    if (container.parentElement !== document.body) {
+      document.body.appendChild(container);
+    }
+    container.setAttribute("data-placement", "floating");
+  };
+
   let firstRender = true;
+  window.addEventListener("resize", syncAdPlacement, { passive: true });
 
   document$.subscribe(() => {
+    syncAdPlacement();
+
     if (firstRender) {
       firstRender = false;
       return;

--- a/docs/stylesheets/ethicalads.css
+++ b/docs/stylesheets/ethicalads.css
@@ -1,19 +1,51 @@
 .mdx-ethicalads-container {
-  display: flex;
-  justify-content: center;
-  padding-top: 0.5rem;
+  position: fixed;
+  right: 1rem;
+  bottom: 1rem;
+  width: min(12rem, calc(100vw - 2rem));
+  margin: 0;
+  padding: 0;
+  z-index: 3;
+  pointer-events: none;
+}
+
+.mdx-ethicalads-container > * {
+  pointer-events: auto;
+}
+
+.mdx-ethicalads-container [data-ea-publisher] {
+  max-width: 100%;
+}
+
+.mdx-ethicalads-container[data-placement="sidebar"] {
+  position: static;
+  width: 100%;
+  max-width: 13.5rem;
+  margin: 1rem 0 0;
+  padding: 0.75rem 0 0;
+  border-top: 0.05rem solid var(--md-default-fg-color--lightest);
+  z-index: auto;
+  pointer-events: auto;
+}
+
+.mdx-ethicalads-container[data-placement="sidebar"] [data-ea-publisher] {
+  margin: 0;
 }
 
 [data-ea-style="stickybox"] {
-  z-index: 30;
+  margin: 0;
 }
 
-@media screen and (max-width: 1300px) {
+@media screen and (max-width: 59.984375em) {
   .mdx-ethicalads-container {
-    padding-top: 0;
+    right: 0.5rem;
+    bottom: 0.5rem;
+    width: min(8rem, calc(100vw - 1rem));
   }
+}
 
-  [data-ea-publisher] {
-    margin: 0.75rem 0 0;
+@media screen and (max-width: 44.984375em) {
+  .mdx-ethicalads-container {
+    width: min(7rem, calc(100vw - 1rem));
   }
 }


### PR DESCRIPTION
## Summary
- move ethical ad container into the docs sidebar on viewports where sidebars are visible
- keep a compact floating bottom-right placement for smaller widths
- re-sync placement on resize and MkDocs instant navigation updates

## Validation
- mkdocs build
- mkdocs build --strict
- Playwright viewport checks across desktop/tablet/mobile sizes