### PR TITLE
Update docs/examples to Chroma 1.5.2 and refresh changelog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ The cookbook is organized as a MkDocs documentation site:
 
 - Documentation uses Markdown with MkDocs Material extensions (admonition, pymdownx, etc.)
 - Code snippets support syntax highlighting and copy buttons
-- Latest ChromaDB version tracked in index.md: 1.5.1
+- Latest ChromaDB version tracked in index.md: 1.5.2
 - New content should follow existing patterns in respective directories
 - Use admonitions for notes, warnings, and tips
 - Include practical examples and code snippets where applicable

--- a/docs/core/install.md
+++ b/docs/core/install.md
@@ -23,13 +23,13 @@ Get a Chroma server running quickly with the CLI or Docker:
 === "Docker"
 
     ```bash
-    docker pull chromadb/chroma:1.5.1 && docker run -p 8000:8000 chromadb/chroma:1.5.1
+    docker pull chromadb/chroma:1.5.2 && docker run -p 8000:8000 chromadb/chroma:1.5.2
     ```
 
     ??? tip "Version pinning"
 
         Avoid relying on `latest` for production or repeatable environments.
-        Pin to a specific image tag (for example `chromadb/chroma:1.5.1`) and upgrade intentionally after validation.
+        Pin to a specific image tag (for example `chromadb/chroma:1.5.2`) and upgrade intentionally after validation.
 
 ## Chroma CLI (Standalone Installer)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,11 +2,18 @@
 
 This is a collection of small guides and recipes to help you get started with Chroma.
 
-Latest ChromaDB version: [1.5.1](https://github.com/chroma-core/chroma/releases/tag/1.5.1)
+Latest ChromaDB version: [1.5.2](https://github.com/chroma-core/chroma/releases/tag/1.5.2)
 
 <div class="api-changelog" markdown="1">
 
-??? info "API Changelog (1.5.1 and 1.5.0)"
+??? info "API Changelog (1.5.2, 1.5.1, and 1.5.0)"
+
+    **Version [1.5.2](https://github.com/chroma-core/chroma/releases/tag/1.5.2) (February 27, 2026)**
+
+    | Area | API-facing change | Reference |
+    |---|---|---|
+    | Python Client | Added `Client.close()` and context manager support (`with` syntax) | [#6373](https://github.com/chroma-core/chroma/pull/6373) |
+    | Embedding Functions | Added Perplexity embedding function support (`Pplx EF`) | [#6511](https://github.com/chroma-core/chroma/pull/6511) |
 
     **Version [1.5.1](https://github.com/chroma-core/chroma/releases/tag/1.5.1) (February 19, 2026)**
 

--- a/docs/integrations/langchain/embeddings.md
+++ b/docs/integrations/langchain/embeddings.md
@@ -1,13 +1,13 @@
 # LangChain Embeddings
 
-This page shows the current Chroma (`1.5.1`) and LangChain embedding integration patterns.
+This page shows the current Chroma (`1.5.2`) and LangChain embedding integration patterns.
 
 ## Use LangChain Embeddings With Chroma Collections
 
-In Chroma `1.5.1`, wrap a LangChain `Embeddings` implementation with
+In Chroma `1.5.2`, wrap a LangChain `Embeddings` implementation with
 `ChromaLangchainEmbeddingFunction`.
 
-!!! note "Query workaround in 1.5.1"
+!!! note "Query workaround in 1.5.2"
 
     If `collection.query(query_texts=[...])` raises an error with wrapped LangChain embeddings,
     use `query_embeddings=[lc_embeddings.embed_query("...")]` instead.
@@ -15,7 +15,7 @@ In Chroma `1.5.1`, wrap a LangChain `Embeddings` implementation with
 === "Hugging Face"
 
     ```python
-    # pip install chromadb==1.5.1 langchain-core langchain-huggingface sentence-transformers
+    # pip install chromadb==1.5.2 langchain-core langchain-huggingface sentence-transformers
     import chromadb
     from chromadb.utils.embedding_functions import ChromaLangchainEmbeddingFunction
     from langchain_huggingface import HuggingFaceEmbeddings
@@ -36,7 +36,7 @@ In Chroma `1.5.1`, wrap a LangChain `Embeddings` implementation with
 === "OpenAI"
 
     ```python
-    # pip install chromadb==1.5.1 langchain-core langchain-openai
+    # pip install chromadb==1.5.2 langchain-core langchain-openai
     import chromadb
     from chromadb.utils.embedding_functions import ChromaLangchainEmbeddingFunction
     from langchain_openai import OpenAIEmbeddings
@@ -57,7 +57,7 @@ In Chroma `1.5.1`, wrap a LangChain `Embeddings` implementation with
 For LangChain vector stores, use the `langchain-chroma` package:
 
 ```python
-# pip install chromadb==1.5.1 langchain-core langchain-chroma langchain-openai
+# pip install chromadb==1.5.2 langchain-core langchain-chroma langchain-openai
 from langchain_chroma import Chroma
 from langchain_openai import OpenAIEmbeddings
 

--- a/docs/integrations/langchain/index.md
+++ b/docs/integrations/langchain/index.md
@@ -4,14 +4,14 @@ Last updated: **February 25, 2026**
 
 ## What's New In This Refresh
 
-- Updated embeddings guidance for Chroma `1.5.1`.
+- Updated embeddings guidance for Chroma `1.5.2`.
 - Replaced legacy vector store imports with `from langchain_chroma import Chroma`.
 - Replaced deprecated adapter usage with `ChromaLangchainEmbeddingFunction`.
 - Added a full runnable example:
   [examples/langchain/python/embeddings_example.py](https://github.com/amikos-tech/chroma-cookbook/blob/main/examples/langchain/python/embeddings_example.py)
 - Added example dependencies:
   [examples/langchain/requirements.txt](https://github.com/amikos-tech/chroma-cookbook/blob/main/examples/langchain/requirements.txt)
-- Documented a Chroma `1.5.1` query workaround for wrapped LangChain embeddings.
+- Documented a Chroma `1.5.2` query workaround for wrapped LangChain embeddings.
 
 ## Guides
 

--- a/docs/running/deployment-patterns.md
+++ b/docs/running/deployment-patterns.md
@@ -124,7 +124,7 @@ A complete runnable version is available at [`examples/deployment-patterns/serve
 ```yaml title="docker-compose.yml"
 services:
   chroma:
-    image: chromadb/chroma:1.5.1
+    image: chromadb/chroma:1.5.2
     ports:
       - "8000:8000"
     volumes:

--- a/docs/running/health-checks.md
+++ b/docs/running/health-checks.md
@@ -10,7 +10,7 @@ if you are deploying Chroma alongside other services that may depend on it.
 ```yaml
 services:
   chromadb:
-    image: chromadb/chroma:1.5.1
+    image: chromadb/chroma:1.5.2
     volumes:
       - ./chroma-data:/data
     ports:

--- a/docs/running/running-chroma.md
+++ b/docs/running/running-chroma.md
@@ -134,7 +134,7 @@ Prerequisites:
 docker run -d --rm --name chromadb \
   -p 8000:8000 \
   -v ./chroma-data:/data \
-  chromadb/chroma:1.5.1
+  chromadb/chroma:1.5.2
 ```
 
 Options:
@@ -142,7 +142,7 @@ Options:
 - `-p 8000:8000` specifies the port on which the Chroma server will be exposed.
 - `-v` specifies a local dir which is where Chroma will store its data so when the container is destroyed the data
   remains. For current Chroma server images, mount `/data` to persist DB files.
-- `chromadb/chroma:1.5.1` indicates the Chroma release version.
+- `chromadb/chroma:1.5.2` indicates the Chroma release version.
 
 !!! note "Current v1.x Images"
 
@@ -167,7 +167,7 @@ Options:
       -v ./chroma-data:/data \
       -v ./chroma.docker.yaml:/chroma/config.yaml:ro \
       -e CONFIG_PATH=/chroma/config.yaml \
-      chromadb/chroma:1.5.1
+      chromadb/chroma:1.5.2
     ```
 
 ### Docker Compose
@@ -181,7 +181,7 @@ Prerequisites:
 ```yaml
 services:
   chromadb:
-    image: chromadb/chroma:1.5.1
+    image: chromadb/chroma:1.5.2
     volumes:
       - ./chroma-data:/data
     ports:
@@ -193,7 +193,7 @@ services:
       retries: 3
 ```
 
-The above will create a container with Chroma `1.5.1`, expose it on local port `8000`, and persist data in
+The above will create a container with Chroma `1.5.2`, expose it on local port `8000`, and persist data in
 `./chroma-data` relative to where `docker-compose.yaml` is run.
 
 ??? example "Optional: Docker Compose with YAML config file (collapsed)"
@@ -201,7 +201,7 @@ The above will create a container with Chroma `1.5.1`, expose it on local port `
     ```yaml
     services:
       chromadb:
-        image: chromadb/chroma:1.5.1
+        image: chromadb/chroma:1.5.2
         volumes:
           - ./chroma-data:/data
           - ./chroma.docker.yaml:/chroma/config.yaml:ro
@@ -249,7 +249,7 @@ Get and install the chart:
 helm repo add chroma https://amikos-tech.github.io/chromadb-chart/
 helm repo update
 helm install chroma chroma/chromadb \
-  --set image.tag="1.5.1"
+  --set image.tag="1.5.2"
 ```
 
 ??? note "Auth values for Chroma `>= 1.0.0`"

--- a/docs/strategies/keyword-search.md
+++ b/docs/strategies/keyword-search.md
@@ -233,7 +233,7 @@ Hints:
 All runnable examples assume a local Chroma server:
 
 ```bash
-docker run --rm -p 8000:8000 chromadb/chroma:1.5.1
+docker run --rm -p 8000:8000 chromadb/chroma:1.5.2
 ```
 
 - [Overview and run commands](https://github.com/amikos-tech/chroma-cookbook/tree/main/examples/keyword-search)

--- a/docs/strategies/metadata-schema-validation.md
+++ b/docs/strategies/metadata-schema-validation.md
@@ -240,7 +240,7 @@ except ValidationError as exc:
 All runnable examples assume a local Chroma server:
 
 ```bash
-docker run --rm -p 8000:8000 chromadb/chroma:1.5.1
+docker run --rm -p 8000:8000 chromadb/chroma:1.5.2
 ```
 
 - [Overview and run commands](https://github.com/amikos-tech/chroma-cookbook/tree/main/examples/metadata-schema)

--- a/examples/deployment-patterns/requirements.txt
+++ b/examples/deployment-patterns/requirements.txt
@@ -1,1 +1,1 @@
-chromadb==1.5.1
+chromadb==1.5.2

--- a/examples/deployment-patterns/server/docker-compose.yml
+++ b/examples/deployment-patterns/server/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   chroma:
-    image: chromadb/chroma:1.5.1
+    image: chromadb/chroma:1.5.2
     ports:
       - "8000:8000"
     volumes:

--- a/examples/filtering/python/filter_examples.py
+++ b/examples/filtering/python/filter_examples.py
@@ -1,7 +1,7 @@
 """Chroma filtering examples - metadata filters, document filters, and pagination.
 
 Requires a running Chroma server, for example:
-    docker run -p 8000:8000 chromadb/chroma:1.5.0
+    docker run -p 8000:8000 chromadb/chroma:1.5.2
 """
 
 import chromadb

--- a/examples/image-search/python/requirements.txt
+++ b/examples/image-search/python/requirements.txt
@@ -1,3 +1,3 @@
-chromadb==1.5.1
+chromadb==1.5.2
 open-clip-torch>=2.24.0
 pillow>=10.0.0

--- a/examples/keyword-search/README.md
+++ b/examples/keyword-search/README.md
@@ -12,7 +12,7 @@ Each example:
 Run Chroma locally:
 
 ```bash
-docker run --rm -p 8000:8000 chromadb/chroma:1.5.1
+docker run --rm -p 8000:8000 chromadb/chroma:1.5.2
 ```
 
 ## Python

--- a/examples/keyword-search/go/main.go
+++ b/examples/keyword-search/go/main.go
@@ -1,7 +1,7 @@
 // Chroma keyword search example using where_document and vector search.
 //
 // Requires a running Chroma server:
-// docker run --rm -p 8000:8000 chromadb/chroma:1.5.1
+// docker run --rm -p 8000:8000 chromadb/chroma:1.5.2
 package main
 
 import (

--- a/examples/keyword-search/python/keyword_search.py
+++ b/examples/keyword-search/python/keyword_search.py
@@ -1,7 +1,7 @@
 """Chroma keyword search example using where_document and vector search.
 
 Requires a running Chroma server:
-    docker run --rm -p 8000:8000 chromadb/chroma:1.5.1
+    docker run --rm -p 8000:8000 chromadb/chroma:1.5.2
 """
 
 import chromadb

--- a/examples/keyword-search/rust/src/main.rs
+++ b/examples/keyword-search/rust/src/main.rs
@@ -1,7 +1,7 @@
 //! Chroma keyword search example using document filters and vector search.
 //!
 //! Requires a running Chroma server:
-//!     docker run --rm -p 8000:8000 chromadb/chroma:1.5.1
+//!     docker run --rm -p 8000:8000 chromadb/chroma:1.5.2
 
 use chroma::client::ChromaHttpClientOptions;
 use chroma::types::{

--- a/examples/keyword-search/typescript/keyword_search.ts
+++ b/examples/keyword-search/typescript/keyword_search.ts
@@ -2,7 +2,7 @@
  * Chroma keyword search example using whereDocument and vector search.
  *
  * Requires a running Chroma server:
- *   docker run --rm -p 8000:8000 chromadb/chroma:1.5.1
+ *   docker run --rm -p 8000:8000 chromadb/chroma:1.5.2
  */
 
 import { ChromaClient } from "chromadb";

--- a/examples/langchain/README.md
+++ b/examples/langchain/README.md
@@ -2,7 +2,7 @@
 
 This example matches:
 
-- `chromadb==1.5.1`
+- `chromadb==1.5.2`
 - current `langchain_chroma` APIs (`from langchain_chroma import Chroma`)
 
 ## Run

--- a/examples/langchain/python/embeddings_example.py
+++ b/examples/langchain/python/embeddings_example.py
@@ -1,4 +1,4 @@
-"""LangChain embeddings example for Chroma 1.5.1 and current LangChain APIs.
+"""LangChain embeddings example for Chroma 1.5.2 and current LangChain APIs.
 
 This script demonstrates:
 1. Using a LangChain embedding model with a native Chroma collection via

--- a/examples/langchain/requirements.txt
+++ b/examples/langchain/requirements.txt
@@ -1,3 +1,3 @@
-chromadb==1.5.1
+chromadb==1.5.2
 langchain-core==1.2.16
 langchain-chroma==1.1.0

--- a/examples/metadata-schema/README.md
+++ b/examples/metadata-schema/README.md
@@ -21,7 +21,7 @@ All examples validate the same contract:
 Run Chroma locally:
 
 ```bash
-docker run --rm -p 8000:8000 chromadb/chroma:1.5.1
+docker run --rm -p 8000:8000 chromadb/chroma:1.5.2
 ```
 
 ## Python (Pydantic)

--- a/examples/metadata-schema/go/main.go
+++ b/examples/metadata-schema/go/main.go
@@ -8,7 +8,7 @@
 //
 // Requires a running Chroma server:
 //
-//	docker run --rm -p 8000:8000 chromadb/chroma:1.5.1
+//	docker run --rm -p 8000:8000 chromadb/chroma:1.5.2
 package main
 
 import (

--- a/examples/metadata-schema/python/schema_validation.py
+++ b/examples/metadata-schema/python/schema_validation.py
@@ -7,7 +7,7 @@ Shows a full roundtrip:
 4) run a filtered query and parse top metadata result
 
 Requires a running Chroma server, for example:
-    docker run --rm -p 8000:8000 chromadb/chroma:1.5.1
+    docker run --rm -p 8000:8000 chromadb/chroma:1.5.2
 """
 
 from typing import Any, Literal

--- a/examples/metadata-schema/rust/src/main.rs
+++ b/examples/metadata-schema/rust/src/main.rs
@@ -7,7 +7,7 @@
 //! 4) run a filtered query and parse top metadata result
 //!
 //! Requires a running Chroma server:
-//!   docker run --rm -p 8000:8000 chromadb/chroma:1.5.1
+//!   docker run --rm -p 8000:8000 chromadb/chroma:1.5.2
 
 use chroma::client::ChromaHttpClientOptions;
 use chroma::types::{

--- a/examples/metadata-schema/typescript/schema_validation.ts
+++ b/examples/metadata-schema/typescript/schema_validation.ts
@@ -8,7 +8,7 @@
  * 4) run a filtered query and parse top metadata result
  *
  * Requires a running Chroma server:
- *   docker run --rm -p 8000:8000 chromadb/chroma:1.5.1
+ *   docker run --rm -p 8000:8000 chromadb/chroma:1.5.2
  */
 
 import { ChromaClient } from "chromadb";


### PR DESCRIPTION
## Summary
- bump cookbook references from Chroma 1.5.1 to 1.5.2 across docs and examples
- add a 1.5.2 API changelog section in docs/index.md (user-facing items only)
- update remaining stale filtering example server tag from 1.5.0 to 1.5.2

## Validation
- mkdocs build -q
- python3 -m compileall -q examples
- Go: go test ./... + go run . in all Go example modules
- Rust: cargo test + cargo run in all Rust example crates
- TypeScript: npm run -s start in collections/filtering/keyword-search/metadata-schema examples
- Python runtime: executed all example scripts in a temporary Python 3.13 venv against chromadb/chroma:1.5.2
- JS install smoke: node examples/install/js/verify.mjs
